### PR TITLE
`skip` header in dynamic-urls

### DIFF
--- a/src/sitemap.rs
+++ b/src/sitemap.rs
@@ -556,6 +556,10 @@ impl SitemapElement {
     pub(crate) fn set_path_params(&mut self, url: &str) {
         let params = utils::parse_path_params(url);
 
+        if !params.is_empty() {
+            self.set_skip(true);
+        }
+
         match self {
             SitemapElement::Section(s) => {
                 s.path_parameters = params;


### PR DESCRIPTION

[Doc](https://github.com/ftd-lang/fpm.dev/commit/d2d28c9f7609c1f71afb4ef44ac21f1a5dc5ecfb)
